### PR TITLE
Added error handling for NotADirectory error and file name too long error

### DIFF
--- a/gtf/middleware.py
+++ b/gtf/middleware.py
@@ -32,19 +32,18 @@ def generic_template_finder_view(request, base_path='', extra_context={}):
     for t in possibilities:
         try:
             response = render(request, t, extra_context)
-        except (TemplateDoesNotExist, NotADirectoryError):
+        except TemplateDoesNotExist:
             continue
         except OSError as e:
             # If there's a directory that matches the template we're looking for,
             # Django will raise a `IsADirectoryError` in `render` instead of a
             # `TemplateDoesNotExist` error. IsADirectoryError was introduced in
             # Python 3 and is a subclass of OSError and its errno corresponds to EISDIR,
-            # but the error is mapped to the Exception NotADirectoryError.
-            # So for Python 2 compatibility, OSError is caught instead of IsADirectoryError
-            if e.errno == errno.EISDIR:
+            # so for Python 2 compatibility, OSError is caught instead of IsADirectoryError
+            if e.errno in [errno.EISDIR, errno.ENOTDIR]:
                 continue
             elif e.errno == errno.ENAMETOOLONG:
-                raise Http404('File name too long')
+                raise Http404
             else:
                 raise
         if t.endswith('.html') and not path.endswith(request.path) and settings.APPEND_SLASH:

--- a/gtf/middleware.py
+++ b/gtf/middleware.py
@@ -43,7 +43,7 @@ def generic_template_finder_view(request, base_path='', extra_context={}):
             if e.errno in [errno.EISDIR, errno.ENOTDIR]:
                 continue
             elif e.errno == errno.ENAMETOOLONG:
-                raise Http404
+                raise Http404('File name too long')
             else:
                 raise
         if t.endswith('.html') and not path.endswith(request.path) and settings.APPEND_SLASH:

--- a/gtf/middleware.py
+++ b/gtf/middleware.py
@@ -32,16 +32,19 @@ def generic_template_finder_view(request, base_path='', extra_context={}):
     for t in possibilities:
         try:
             response = render(request, t, extra_context)
-        except (TemplateDoesNotExist):
+        except (TemplateDoesNotExist, NotADirectoryError):
             continue
         except OSError as e:
             # If there's a directory that matches the template we're looking for,
             # Django will raise a `IsADirectoryError` in `render` instead of a
             # `TemplateDoesNotExist` error. IsADirectoryError was introduced in
             # Python 3 and is a subclass of OSError and its errno corresponds to EISDIR,
-            # so for Python 2 compatibility, OSError is caught instead of IsADirectoryError
+            # but the error is mapped to the Exception NotADirectoryError.
+            # So for Python 2 compatibility, OSError is caught instead of IsADirectoryError
             if e.errno == errno.EISDIR:
                 continue
+            elif e.errno == errno.ENAMETOOLONG:
+                raise Http404('File name too long')
             else:
                 raise
         if t.endswith('.html') and not path.endswith(request.path) and settings.APPEND_SLASH:


### PR DESCRIPTION
https://docs.python.org/3/library/errno.html

1. Updated the error handling for NotADirectory
2. Added error handling for File name too long